### PR TITLE
refactor: remove utils types definition from globals.d.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@endpass/class": "^0.18.6",
     "@endpass/faucet": "^0.2.1",
     "@endpass/ui": "^0.15.52",
-    "@endpass/utils": "^1.8.3",
+    "@endpass/utils": "^1.8.6",
     "axios": "^0.19.0",
     "bignumber.js": "^9.0.0",
     "ethereum-blockies-base64": "^1.0.2",

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -70,10 +70,7 @@ export const WIDGET_RESIZE_DURATION = 300;
 export const LOCALES = ['en'];
 
 /**
- * @type {{
- *   kdf: string,
- *   n: number
- * }}
+ * @type {KDFEncryptOptions}
  */
 export const ENCRYPT_OPTIONS = {
   kdf: ENV.VUE_APP_KDF_PARAMS_KDF,

--- a/src/controllers/WalletController.js
+++ b/src/controllers/WalletController.js
@@ -46,7 +46,9 @@ class WalletController extends VuexModule {
       v3KeystoreChildWallet,
       encryptedSeed,
       seedKey,
-    } = await walletGen.createComplex(password, ENCRYPT_OPTIONS);
+    } = await walletGen.createComplex(
+      password, /** @type {KDFEncryptOptions} */ (ENCRYPT_OPTIONS)
+    );
     const info = {
       address: v3KeystoreHdWallet.address,
       type: WALLET_TYPES.HD_MAIN,

--- a/src/controllers/WalletController.js
+++ b/src/controllers/WalletController.js
@@ -34,7 +34,7 @@ class WalletController extends VuexModule {
    *
    * @param {object} params
    * @param {string} params.password
-   * @return {Promise<{v3KeystoreHdWallet: v3Keystore, encryptedSeed: string, v3KeystoreChildWallet: v3Keystore, seedKey: string, info: keystoreInfo}>}
+   * @return {Promise<{v3KeystoreHdWallet: V3Keystore, encryptedSeed: string, v3KeystoreChildWallet: V3Keystore, seedKey: string, info: keystoreInfo}>}
    */
   @Action
   async generateWallet({ password }) {
@@ -64,10 +64,10 @@ class WalletController extends VuexModule {
   /**
    *
    * @param {object} params
-   * @param {v3Keystore} params.v3KeystoreHdWallet
+   * @param {V3Keystore} params.v3KeystoreHdWallet
    * @param {keystoreInfo} params.info
    * @param {string} params.encryptedSeed
-   * @param {v3Keystore} params.v3KeystoreChildWallet
+   * @param {V3Keystore} params.v3KeystoreChildWallet
    * @return {Promise<void>}
    */
   @Action

--- a/src/controllers/WalletController.js
+++ b/src/controllers/WalletController.js
@@ -46,9 +46,7 @@ class WalletController extends VuexModule {
       v3KeystoreChildWallet,
       encryptedSeed,
       seedKey,
-    } = await walletGen.createComplex(
-      password, /** @type {KDFEncryptOptions} */ (ENCRYPT_OPTIONS)
-    );
+    } = await walletGen.createComplex(password, ENCRYPT_OPTIONS);
     const info = {
       address: v3KeystoreHdWallet.address,
       type: WALLET_TYPES.HD_MAIN,

--- a/src/types/globals.d.ts
+++ b/src/types/globals.d.ts
@@ -12,29 +12,6 @@ declare namespace ENV {
   const VUE_APP_SHOW_VERSION_INFO: boolean;
 }
 
-declare module '@endpass/utils/date' {
-  function formateDate(date: Date): string;
-}
-
-declare module '@endpass/utils/mapToQueryString' {
-  function mapToQueryString(url: string, params: object): string;
-  export = mapToQueryString;
-}
-
-declare module '@endpass/utils/generators' {
-  function repeatWithInterval(ms: number): Generator;
-  function sleep<T>(ms: number, result: T): Promise<T>;
-}
-
-declare module '@endpass/utils/walletGen' {
-  function createComplex(password: string, options: object): {
-    v3KeystoreHdWallet: v3Keystore,
-    v3KeystoreChildWallet: v3Keystore,
-    encryptedSeed: string,
-    seedKey: string,
-  };
-}
-
 interface Window {
   e2eBridge: object;
 }

--- a/src/types/globals.d.ts
+++ b/src/types/globals.d.ts
@@ -6,7 +6,7 @@ declare namespace ENV {
   const VUE_APP_IS_PRODUCTION: boolean;
   const VUE_APP_GOOGLE_CLIENT_ID: string;
   const VUE_APP_GIT_CLIENT_ID: string;
-  const VUE_APP_KDF_PARAMS_KDF: string;
+  const VUE_APP_KDF_PARAMS_KDF: "scrypt";
   const VUE_APP_IS_E2E_CONNECT: boolean;
   const VUE_APP_KDF_PARAMS_N: number;
   const VUE_APP_SHOW_VERSION_INFO: boolean;

--- a/src/types/globals.d.ts
+++ b/src/types/globals.d.ts
@@ -6,7 +6,7 @@ declare namespace ENV {
   const VUE_APP_IS_PRODUCTION: boolean;
   const VUE_APP_GOOGLE_CLIENT_ID: string;
   const VUE_APP_GIT_CLIENT_ID: string;
-  const VUE_APP_KDF_PARAMS_KDF: "scrypt";
+  const VUE_APP_KDF_PARAMS_KDF: KDFTypes.KdfProperty;
   const VUE_APP_IS_E2E_CONNECT: boolean;
   const VUE_APP_KDF_PARAMS_N: number;
   const VUE_APP_SHOW_VERSION_INFO: boolean;

--- a/src/types/keystore.d.ts
+++ b/src/types/keystore.d.ts
@@ -3,23 +3,3 @@ type keystoreInfo = {
   type: string,
   hidden: boolean,
 }
-
-type v3Keystore = {
-  crypto: {
-    cipher: string,
-    ciphertext: string,
-    cipherparams: { iv: string },
-    mac: string,
-    kdf: string,
-    kdfparams: {
-      dklen: number,
-      n: number,
-      r: number,
-      p: number,
-      salt: string,
-    },
-  },
-  id: string,
-  version: number,
-  address: string,
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1428,6 +1428,22 @@
     node-notifier "^5.4.3"
     secp256k1 "^3.7.1"
 
+"@endpass/utils@^1.8.6":
+  version "1.8.6"
+  resolved "https://registry.yarnpkg.com/@endpass/utils/-/utils-1.8.6.tgz#ebf6e0f5f111749649db5c7beedce165bc40c3b2"
+  integrity sha512-hA13wGMIMU8Z/OeE/ZNMpNRXXGChUcR0wxB8Aj8tNiAjwGqv7UcqqtI/xaI53gEcWPa9tshmFnqOXJUuNSDIkA==
+  dependencies:
+    bip39 "^3.0.2"
+    bs58check "^2.1.2"
+    dayjs "^1.8.16"
+    eth-ecies "^1.0.3"
+    ethereumjs-wallet "^0.6.3"
+    export-files "^2.1.1"
+    keythereum "^1.0.4"
+    lodash "^4.17.15"
+    node-notifier "^5.4.3"
+    secp256k1 "^3.7.1"
+
 "@endpass/vue-i18n-translate-checker@^0.0.4":
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/@endpass/vue-i18n-translate-checker/-/vue-i18n-translate-checker-0.0.4.tgz#bba36b880df445449e2b01a8fdc4f8094f702123"


### PR DESCRIPTION
Definitions of utils types was successfully removed from globals.d.ts declaration file in favor of types definition in `@endpass/utils` module