### PR TITLE
E-342 fix: replace GET with POST for more secure calls

### DIFF
--- a/src/service/auth.js
+++ b/src/service/auth.js
@@ -79,7 +79,9 @@ const authWithCode = async ({
  */
 const authWithGoogle = idToken =>
   request
-    .get(`${identityBaseUrl}/auth/google?token=${encodeURIComponent(idToken)}`)
+    .post(`${identityBaseUrl}/auth/google`, {
+      token: idToken,
+    })
     .then(res => {
       if (!res.success) throw new Error(res.message);
       return res;
@@ -94,7 +96,9 @@ const authWithGoogle = idToken =>
  */
 const authWithGitHub = code =>
   request
-    .get(`${identityBaseUrl}/auth/github?code=${encodeURIComponent(code)}`)
+    .post(`${identityBaseUrl}/auth/github`, {
+      code,
+    })
     .then(res => {
       if (!res.success) throw new Error(res.message);
       return res;

--- a/tests/unit/specs/service/auth.spec.js
+++ b/tests/unit/specs/service/auth.spec.js
@@ -152,4 +152,40 @@ describe('auth service', () => {
       });
     });
   });
+
+  describe('authWithGoogle', () => {
+    const url = `${identityBaseUrl}/auth/google`;
+
+    it('should return 200 OK', async () => {
+      expect.assertions(1);
+      const token = '123';
+
+      axiosMock.onPost(url).reply(200, {
+        success: true,
+      });
+      const res = await authService.authWithGoogle(token);
+
+      expect(res).toEqual({
+        success: true,
+      });
+    });
+  });
+
+  describe('authWithGithub', () => {
+    const url = `${identityBaseUrl}/auth/github`;
+
+    it('should return 200 OK', async () => {
+      expect.assertions(1);
+      const code = '123';
+
+      axiosMock.onPost(url).reply(200, {
+        success: true,
+      });
+      const res = await authService.authWithGitHub(code);
+
+      expect(res).toEqual({
+        success: true,
+      });
+    });
+  });
 });

--- a/tests/unit/specs/service/auth.spec.js
+++ b/tests/unit/specs/service/auth.spec.js
@@ -155,10 +155,10 @@ describe('auth service', () => {
 
   describe('authWithGoogle', () => {
     const url = `${identityBaseUrl}/auth/google`;
+    const token = '123';
 
     it('should return 200 OK', async () => {
       expect.assertions(1);
-      const token = '123';
 
       axiosMock.onPost(url).reply(200, {
         success: true,
@@ -169,14 +169,29 @@ describe('auth service', () => {
         success: true,
       });
     });
+
+    it('should throw error on invalid request', async () => {
+      expect.assertions(1);
+      const message = 'Incorrect request';
+
+      axiosMock.onPost(url).reply(500, {
+        message,
+      });
+
+      try {
+        await authService.authWithGoogle(token);
+      } catch (e) {
+        expect(e.message).toBe(message);
+      }
+    });
   });
 
   describe('authWithGithub', () => {
     const url = `${identityBaseUrl}/auth/github`;
+    const code = '123';
 
     it('should return 200 OK', async () => {
       expect.assertions(1);
-      const code = '123';
 
       axiosMock.onPost(url).reply(200, {
         success: true,
@@ -186,6 +201,21 @@ describe('auth service', () => {
       expect(res).toEqual({
         success: true,
       });
+    });
+
+    it('should throw error on invalid request', async () => {
+      expect.assertions(1);
+      const message = 'Incorrect request';
+
+      axiosMock.onPost(url).reply(500, {
+        message,
+      });
+
+      try {
+        await authService.authWithGitHub(code);
+      } catch (e) {
+        expect(e.message).toBe(message);
+      }
     });
   });
 });


### PR DESCRIPTION
Replace GET method with POST for `auth/google` and `auth/github` calls for more security